### PR TITLE
Add standard Contributing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Contributions are welcome! To contribute:
 
 Please ensure your code adheres to the existing style and includes relevant tests and documentation.
 
+## Contributing
+
+Contributions are welcome! To contribute:
+
+1. Fork the repository.
+2. Create a new branch (`git checkout -b feature-name`).
+3. Make your changes and commit with clear messages (`git commit -m 'Add some feature'`).
+4. Push to your branch (`git push origin feature-name`).
+5. Open a Pull Request describing your changes.
+
+Please ensure your code adheres to the existing style and includes relevant tests and documentation.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
Adds a standard-format Contributing section to the README, describing the fork, branch, commit, push, and PR workflow, along with a note to follow project style and include tests/documentation.